### PR TITLE
Erweiterungen & ein bisschen refactored

### DIFF
--- a/discoverecs.py
+++ b/discoverecs.py
@@ -305,6 +305,9 @@ def extract_path_interval(env_variable):
 def task_info_to_targets(task_info):
     if not task_info.valid():
         return []
+    LABEL_CLEAN_REGEX = re.compile(r"[^\w]", re.IGNORECASE)
+    clean_label = lambda x: LABEL_CLEAN_REGEX.sub("_", x)
+    ecs_task_tags = {clean_label(tag['key']): tag['value']for tag in task_info.tags}
     for container_definition in task_info.task_definition['containerDefinitions']:
         prometheus = get_environment_var(container_definition['environment'], 'PROMETHEUS')
         metrics_path = get_environment_var(container_definition['environment'], 'PROMETHEUS_ENDPOINT')

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from collections import defaultdict
+from typing import Dict, Iterator, List
 import boto3
 import botocore
 import json
@@ -143,11 +144,11 @@ class TaskInfoDiscoverer:
         self.container_instance_cache.flip()
         self.ec2_instance_cache.flip()
 
-    def describe_tasks(self, cluster_arn, task_arns):
+    def describe_tasks(self, cluster_arn, task_arns) -> List[Dict]:
         def fetcher_task_definition(arn):
             return self.ecs_client.describe_task_definition(taskDefinition=arn)['taskDefinition']
 
-        def fetcher(fetch_task_arns):
+        def fetcher(fetch_task_arns) -> Dict[str, Dict]:
             tasks = {}
             result = self.ecs_client.describe_tasks(cluster=cluster_arn, tasks=fetch_task_arns)
             if 'tasks' in result:
@@ -175,7 +176,7 @@ class TaskInfoDiscoverer:
             return tasks
         return self.task_cache.get_dict(task_arns, fetcher).values()
 
-    def create_task_infos(self, cluster_arn, task_arns):
+    def create_task_infos(self, cluster_arn, task_arns) -> Iterator[TaskInfo]:
         return map(lambda t: TaskInfo(t), self.describe_tasks(cluster_arn, task_arns))
 
     def add_task_definitions(self, task_infos):

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -261,7 +261,7 @@ class Target:
     def __init__(self, ip, port, metrics_path, p_instance, tags,
                  ecs_task_id, ecs_task_name, ecs_task_version,
                  ecs_container_id, ecs_cluster_name, ec2_instance_id,
-                 container_image, ecs_task_tags = {}):
+                 ecs_task_tags = {}):
         self.ip = ip
         self.port = port
         self.metrics_path = metrics_path
@@ -323,7 +323,7 @@ def task_info_to_targets(task_info):
             for container in containers:
                 ecs_task_name=extract_name(task_info.task['taskDefinitionArn'])
                 has_host_port_mapping = 'portMappings' in container_definition and len(container_definition['portMappings']) > 0
-                container_image=container.get('image', 'undefined')
+                prom_tags += f"container_image={container.get('image', 'undefined')},"
                 if prom_port:
                     first_port = prom_port
                 elif task_info.task_definition.get('networkMode') in ('host', 'awsvpc'):
@@ -368,7 +368,6 @@ def task_info_to_targets(task_info):
                     ecs_container_id=ecs_container_id,
                     ecs_cluster_name=ecs_cluster_name,
                     ec2_instance_id=ec2_instance_id,
-                    container_image=container_image,
                     ecs_task_tags=ecs_task_tags
                     )]
     return []
@@ -430,7 +429,6 @@ class Main:
                 job = {
                     'targets' : [target.ip + ':' + target.port],
                     'labels' : {
-                        'container_image': target.container_image,
                         'instance': target.p_instance,
                         'job' : target.ecs_task_name,
                         'tags' : target.tags,

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -260,7 +260,8 @@ class Target:
 
     def __init__(self, ip, port, metrics_path, p_instance, tags,
                  ecs_task_id, ecs_task_name, ecs_task_version,
-                 ecs_container_id, ecs_cluster_name, ec2_instance_id, container_image):
+                 ecs_container_id, ecs_cluster_name, ec2_instance_id,
+                 container_image, ecs_task_tags = {}):
         self.ip = ip
         self.port = port
         self.metrics_path = metrics_path
@@ -272,6 +273,7 @@ class Target:
         self.ecs_container_id = ecs_container_id
         self.ecs_cluster_name = ecs_cluster_name
         self.ec2_instance_id = ec2_instance_id
+        self.ecs_task_tags = ecs_task_tags
         self.container_image = container_image
 
 def get_environment_var(environment, name):
@@ -366,7 +368,9 @@ def task_info_to_targets(task_info):
                     ecs_container_id=ecs_container_id,
                     ecs_cluster_name=ecs_cluster_name,
                     ec2_instance_id=ec2_instance_id,
-                    container_image=container_image)]
+                    container_image=container_image,
+                    ecs_task_tags=ecs_task_tags
+                    )]
     return []
 
 class Main:
@@ -430,7 +434,8 @@ class Main:
                         'instance': target.p_instance,
                         'job' : target.ecs_task_name,
                         'tags' : target.tags,
-                        'metrics_path' : path
+                        'metrics_path' : path,
+                        **target.ecs_task_tags
                     }
                 }
                 if labels:


### PR DESCRIPTION
Tags aus der Taskdefinition werden als Label für Prometheus gesetzt.

Beispiel:

```
 pipenv run python discoverecs.py --directory /test 
Starting. Directory: /test. Interval: 60s.
task_cache 0 6 task_definition_cache 0 6 6 container_instance_cache 0 0 ec2_instance_cache 0 0 0
Targets: 5
{'targets': ['10.177.106.170:8081'], 'labels': {'instance': '10.177.106.170:8081', 'job': 'pbuservicesunitykonditionsermittlungpipelinestackinternstagepbuservicesunitykonditionsermittlungservicepbuservicesunitykonditionsermittlungserviceinterntaskdefinitionF1C2DC8A', 'tags': ',context_path=aws.demo.pbu-services-unity-konditionsermittlung-service-intern,stage=undefined,container_image=029689129113.dkr.ecr.eu-central-1.amazonaws.com/pbu-services-unity-konditionsermittlung:2021.01.12-12.28.41,', 'metrics_path': '/actuator/prometheus', 'context_path': 'baufi.team.pbu', 'owner_scope': 'baufinanzierung', 'stage': 'intern', 'owner_domain': 'pbu-deuba', 'repository': 'https://github.com/europace-postbank/pbu-services-unity-konditionsermittlung', 'application_id': 'pbu-services-unity-konditionsermittlung', 'cost_center': '6600', 'ecs_task_id': 'db-link', 'ecs_task_version': '13', 'ecs_cluster': 'db-link'}}
{'targets': ['10.177.104.78:8081'], 'labels': {'instance': '10.177.104.78:8081', 'job': 'pbuservicesunitykonditionsermittlungpipelinestackinternstagepbuservicesunitykonditionsermittlungservicepbuservicesunitykonditionsermittlungserviceinterntaskdefinitionF1C2DC8A', 'tags': ',context_path=aws.demo.pbu-services-unity-konditionsermittlung-service-intern,stage=undefined,container_image=029689129113.dkr.ecr.eu-central-1.amazonaws.com/pbu-services-unity-konditionsermittlung:2021.01.11-17.25.14,', 'metrics_path': '/actuator/prometheus', 'context_path': 'baufi.team.pbu', 'owner_scope': 'baufinanzierung', 'stage': 'intern', 'owner_domain': 'pbu-deuba', 'repository': 'https://github.com/europace-postbank/pbu-services-unity-konditionsermittlung', 'application_id': 'pbu-services-unity-konditionsermittlung', 'cost_center': '6600', 'ecs_task_id': 'db-link', 'ecs_task_version': '12', 'ecs_cluster': 'db-link'}}
{'targets': ['10.177.105.167:8081'], 'labels': {'instance': '10.177.105.167:8081', 'job': 'unterlagenexportlistenerpipelinestackteststageulaunterlagenexportlistenerserviceservicesdeubaulaunterlagenexportlistenertaskdefinition550C72FC', 'tags': ',context_path=aws.demo.services_deuba_ula_unterlagen_export_listener,stage=undefined,container_image=029689129113.dkr.ecr.eu-central-1.amazonaws.com/pbu-services-deuba-ula-unterlagen-export-listener:2021.01.12-11.44.00,', 'metrics_path': '/actuator/prometheus', 'context_path': 'baufi.team.pbu', 'owner_scope': 'baufinanzierung', 'stage': 'test', 'owner_domain': 'pbu', 'repository': 'https://github.com/europace-postbank/pbu-service-deuba-ula-unterlagen-export-listener', 'application_id': 'deuba-ula-unterlagen-export-listener', 'cost_center': '6600', 'ecs_task_id': 'db-link', 'ecs_task_version': '62', 'ecs_cluster': 'db-link'}}
{'targets': ['10.177.106.78:8081'], 'labels': {'instance': '10.177.106.78:8081', 'job': 'unterlagenuploaderpipelinestackteststagedeubaunterlagenuploaderservicedeubaunterlagenuploadertaskdefinition8EE870E8', 'tags': ',context_path=aws.demo.deuba_unterlagen_uploader,stage=undefined,container_image=029689129113.dkr.ecr.eu-central-1.amazonaws.com/pbu-services-deuba-unterlagen-uploader:2021.01.11-18.58.11,', 'metrics_path': '/actuator/prometheus', 'context_path': 'baufi.team.pbu', 'owner_scope': 'baufinanzierung', 'stage': 'test', 'owner_domain': 'pbu', 'repository': 'https://github.com/europace-postbank/pbu-service-deuba-unterlagen-uploader', 'application_id': 'deuba-unterlagen-uploader', 'cost_center': '6600', 'ecs_task_id': 'db-link', 'ecs_task_version': '33', 'ecs_cluster': 'db-link'}}
{'targets': ['10.177.107.10:8081'], 'labels': {'instance': '10.177.107.10:8081', 'job': 'servicesloadpipelinestackteststageservicesloadservicepbuservicesloadservicetesttaskdefinition466176A1', 'tags': ',context_path=aws.demo.pbu-services-load-service-test,stage=undefined,container_image=029689129113.dkr.ecr.eu-central-1.amazonaws.com/services-load:2021.01.08-19.37.13,', 'metrics_path': '/actuator/prometheus', 'context_path': 'baufi.team.pbu', 'owner_scope': 'baufinanzierung', 'stage': 'test', 'owner_domain': 'pbu-deuba', 'repository': 'https://github.com/europace-postbank/pbu-aws-service-load', 'application_id': 'services-load', 'cost_center': '6600', 'ecs_task_id': 'services', 'ecs_task_version': '12', 'ecs_cluster': 'services'}}
```